### PR TITLE
Add Nodes Contribution workflow summary node

### DIFF
--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -128,9 +128,9 @@ class OCS_NodesContribution:
             for node_id in members:
                 details_lines.append(f"  • {node_id}")
 
-        ui_lines = tuple(breakdown_lines + details_lines)
+        ui_text = "\n".join(breakdown_lines + details_lines)
 
-        return {"result": (breakdown,), "ui": {"text": ui_lines}}
+        return {"result": (breakdown,), "ui": {"text": (ui_text,)}}
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -13,9 +13,11 @@ NodeDict = Dict[str, object]
 class OCS_NodesContribution:
     """Summarise how many nodes in the active workflow come from each suite."""
 
+    NAME = "Nodes Contribution"
     CATEGORY = "OCS Nodes"
-    RETURN_TYPES = ()
-    FUNCTION = "summarise"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("text",)
+    FUNCTION = "main"
     OUTPUT_NODE = True
     DESCRIPTION = (
         "Counts the nodes used in the current workflow grouped by their source suite,"
@@ -110,17 +112,49 @@ class OCS_NodesContribution:
                 node["widgets_values"] = [value]
                 break
 
-    def summarise(
+    def _ensure_text_widget(
+        self,
+        extra_pnginfo: Dict[str, object] | None,
+        unique_id: str | int | None,
+    ) -> None:
+        """Guarantee a text widget exists so the node shows an empty panel on load."""
+
+        if not extra_pnginfo or unique_id is None:
+            return
+
+        workflow_info = extra_pnginfo.setdefault("workflow", {})
+        if not isinstance(workflow_info, dict):
+            return
+
+        nodes = workflow_info.setdefault("nodes", [])
+        if not isinstance(nodes, list):
+            return
+
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            if str(node.get("id")) == str(unique_id):
+                current = node.setdefault("widgets_values", [])
+                if isinstance(current, list):
+                    if not current:
+                        current.append("")
+                else:
+                    node["widgets_values"] = [""]
+                return
+
+    def main(
         self,
         workflow: Workflow | None = None,
         unique_id: str | int | None = None,
         extra_pnginfo: Dict[str, object] | None = None,
     ):
+        self._ensure_text_widget(extra_pnginfo, unique_id)
+
         suites = self._installed_suites()
         if not suites:
             message = "No node suites detected."
             self._set_widget_text(extra_pnginfo, unique_id, message)
-            return {"ui": {"text": (message,)}}
+            return {"ui": {"text": (message,)}, "result": (message,)}
 
         class_to_suite: Dict[str, str] = {
             node_id: suite for suite, members in suites.items() for node_id in members
@@ -159,7 +193,7 @@ class OCS_NodesContribution:
         ui_text = "\n".join(breakdown_lines + details_lines)
 
         self._set_widget_text(extra_pnginfo, unique_id, ui_text)
-        return {"ui": {"text": (ui_text,)}}
+        return {"ui": {"text": (ui_text,)}, "result": (ui_text,)}
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -115,9 +115,21 @@ class OCS_NodesContribution:
         sorted_lines = sorted(
             counts.items(), key=lambda item: (-item[1], item[0].lower())
         )
-        breakdown = "\n".join(f"{suite} - {count}" for suite, count in sorted_lines)
+        breakdown_lines = [f"{suite} - {count}" for suite, count in sorted_lines]
+        breakdown = "\n".join(breakdown_lines)
 
-        return {"result": (breakdown,), "ui": {"text": breakdown}}
+        details_lines = ["Loaded node classes:"]
+        for suite in sorted(suites):
+            members = sorted(suites[suite])
+            details_lines.append(
+                f"{suite} ({len(members)} class{'es' if len(members) != 1 else ''})"
+            )
+            for node_id in members:
+                details_lines.append(f"  • {node_id}")
+
+        ui_text = f"{breakdown}\n\n" + "\n".join(details_lines)
+
+        return {"result": (breakdown,), "ui": {"text": ui_text}}
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -18,6 +18,7 @@ class OCS_NodesContribution:
     RETURN_NAMES: Tuple[str, ...] = ("breakdown",)
     FUNCTION = "summarise"
     OUTPUT_IS_LIST = (False,)
+    OUTPUT_NODE = True
     DESCRIPTION = (
         "Counts the nodes used in the current workflow grouped by their source suite,"
         " including suites that are installed but not referenced."

--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 import sys
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable
 
 Workflow = Dict[str, object]
 NodeDict = Dict[str, object]
@@ -14,10 +14,8 @@ class OCS_NodesContribution:
     """Summarise how many nodes in the active workflow come from each suite."""
 
     CATEGORY = "OCS Nodes"
-    RETURN_TYPES: Tuple[str, ...] = ("STRING",)
-    RETURN_NAMES: Tuple[str, ...] = ("breakdown",)
+    RETURN_TYPES = ()
     FUNCTION = "summarise"
-    OUTPUT_IS_LIST = (False,)
     OUTPUT_NODE = True
     DESCRIPTION = (
         "Counts the nodes used in the current workflow grouped by their source suite,"
@@ -30,6 +28,8 @@ class OCS_NodesContribution:
             "required": {},
             "hidden": {
                 "workflow": "WORKFLOW",
+                "unique_id": "UNIQUE_ID",
+                "extra_pnginfo": "EXTRA_PNGINFO",
             },
         }
 
@@ -86,11 +86,41 @@ class OCS_NodesContribution:
         return []
 
     # ------------------------------------------------------------------ main API
-    def summarise(self, workflow: Workflow | None = None):
+    @staticmethod
+    def _set_widget_text(
+        extra_pnginfo: Dict[str, object] | None,
+        unique_id: str | int | None,
+        value: str,
+    ) -> None:
+        if not extra_pnginfo or unique_id is None:
+            return
+
+        workflow_info = extra_pnginfo.get("workflow")
+        if not isinstance(workflow_info, dict):
+            return
+
+        nodes = workflow_info.get("nodes")
+        if not isinstance(nodes, list):
+            return
+
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            if str(node.get("id")) == str(unique_id):
+                node["widgets_values"] = [value]
+                break
+
+    def summarise(
+        self,
+        workflow: Workflow | None = None,
+        unique_id: str | int | None = None,
+        extra_pnginfo: Dict[str, object] | None = None,
+    ):
         suites = self._installed_suites()
         if not suites:
             message = "No node suites detected."
-            return {"result": (message,), "ui": {"text": (message,)}}
+            self._set_widget_text(extra_pnginfo, unique_id, message)
+            return {"ui": {"text": (message,)}}
 
         class_to_suite: Dict[str, str] = {
             node_id: suite for suite, members in suites.items() for node_id in members
@@ -117,8 +147,6 @@ class OCS_NodesContribution:
             counts.items(), key=lambda item: (-item[1], item[0].lower())
         )
         breakdown_lines = [f"{suite} - {count}" for suite, count in sorted_lines]
-        breakdown = "\n".join(breakdown_lines)
-
         details_lines = ["", "Loaded node classes:"]
         for suite in sorted(suites):
             members = sorted(suites[suite])
@@ -130,7 +158,8 @@ class OCS_NodesContribution:
 
         ui_text = "\n".join(breakdown_lines + details_lines)
 
-        return {"result": (breakdown,), "ui": {"text": (ui_text,)}}
+        self._set_widget_text(extra_pnginfo, unique_id, ui_text)
+        return {"ui": {"text": (ui_text,)}}
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -90,7 +90,7 @@ class OCS_NodesContribution:
         suites = self._installed_suites()
         if not suites:
             message = "No node suites detected."
-            return {"result": (message,), "ui": {"text": message}}
+            return {"result": (message,), "ui": {"text": (message,)}}
 
         class_to_suite: Dict[str, str] = {
             node_id: suite for suite, members in suites.items() for node_id in members
@@ -119,7 +119,7 @@ class OCS_NodesContribution:
         breakdown_lines = [f"{suite} - {count}" for suite, count in sorted_lines]
         breakdown = "\n".join(breakdown_lines)
 
-        details_lines = ["Loaded node classes:"]
+        details_lines = ["", "Loaded node classes:"]
         for suite in sorted(suites):
             members = sorted(suites[suite])
             details_lines.append(
@@ -128,9 +128,9 @@ class OCS_NodesContribution:
             for node_id in members:
                 details_lines.append(f"  • {node_id}")
 
-        ui_text = f"{breakdown}\n\n" + "\n".join(details_lines)
+        ui_lines = tuple(breakdown_lines + details_lines)
 
-        return {"result": (breakdown,), "ui": {"text": ui_text}}
+        return {"result": (breakdown,), "ui": {"text": ui_lines}}
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes/nodes_contribution.py
+++ b/nodes/nodes_contribution.py
@@ -1,0 +1,129 @@
+"""Workflow analysis utilities for OCS Nodes."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import sys
+from typing import Dict, Iterable, Tuple
+
+Workflow = Dict[str, object]
+NodeDict = Dict[str, object]
+
+
+class OCS_NodesContribution:
+    """Summarise how many nodes in the active workflow come from each suite."""
+
+    CATEGORY = "OCS Nodes"
+    RETURN_TYPES: Tuple[str, ...] = ("STRING",)
+    RETURN_NAMES: Tuple[str, ...] = ("breakdown",)
+    FUNCTION = "summarise"
+    OUTPUT_IS_LIST = (False,)
+    DESCRIPTION = (
+        "Counts the nodes used in the current workflow grouped by their source suite,"
+        " including suites that are installed but not referenced."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {},
+            "hidden": {
+                "workflow": "WORKFLOW",
+            },
+        }
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _iter_node_class_mappings() -> Dict[str, type]:
+        """Collect *all* NODE_CLASS_MAPPINGS exposed by loaded modules."""
+
+        combined: Dict[str, type] = {}
+        for module in list(sys.modules.values()):
+            mapping = getattr(module, "NODE_CLASS_MAPPINGS", None)
+            if isinstance(mapping, dict):
+                for key, value in mapping.items():
+                    combined.setdefault(key, value)
+        return combined
+
+    @staticmethod
+    def _suite_from_python_module(rel_module: str | None) -> str:
+        if not rel_module:
+            return "Unknown"
+
+        parts = rel_module.split(".")
+        if not parts:
+            return "Unknown"
+
+        head = parts[0]
+        if head == "custom_nodes" and len(parts) > 1:
+            head = parts[1]
+        elif head in {"nodes", "comfy"}:
+            return "Comfy Core"
+
+        if head == "comfy_extras":
+            return "Comfy Extras"
+        if head == "comfy_api_nodes":
+            return "Comfy API Nodes"
+
+        return head
+
+    def _installed_suites(self) -> Dict[str, set[str]]:
+        class_map = self._iter_node_class_mappings()
+        suites: Dict[str, set[str]] = defaultdict(set)
+        for node_id, cls in class_map.items():
+            rel_module = getattr(cls, "RELATIVE_PYTHON_MODULE", None)
+            suite = self._suite_from_python_module(rel_module)
+            suites[suite].add(node_id)
+        return suites
+
+    @staticmethod
+    def _workflow_nodes(workflow: Workflow | None) -> Iterable[NodeDict]:
+        if isinstance(workflow, dict):
+            nodes = workflow.get("nodes")
+            if isinstance(nodes, list):
+                return nodes
+        return []
+
+    # ------------------------------------------------------------------ main API
+    def summarise(self, workflow: Workflow | None = None):
+        suites = self._installed_suites()
+        if not suites:
+            message = "No node suites detected."
+            return {"result": (message,), "ui": {"text": message}}
+
+        class_to_suite: Dict[str, str] = {
+            node_id: suite for suite, members in suites.items() for node_id in members
+        }
+
+        counts = {suite: 0 for suite in suites}
+        unknown_count = 0
+
+        for node in self._workflow_nodes(workflow):
+            class_type = node.get("class_type") if isinstance(node, dict) else None
+            if not class_type and isinstance(node, dict):
+                class_type = node.get("type")
+
+            if isinstance(class_type, str) and class_type in class_to_suite:
+                counts[class_to_suite[class_type]] += 1
+            elif class_type:
+                unknown_count += 1
+
+        if unknown_count:
+            counts.setdefault("Unregistered", 0)
+            counts["Unregistered"] += unknown_count
+
+        sorted_lines = sorted(
+            counts.items(), key=lambda item: (-item[1], item[0].lower())
+        )
+        breakdown = "\n".join(f"{suite} - {count}" for suite, count in sorted_lines)
+
+        return {"result": (breakdown,), "ui": {"text": breakdown}}
+
+
+NODE_CLASS_MAPPINGS = {
+    "OCS_NodesContribution": OCS_NodesContribution,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "OCS_NodesContribution": "Nodes Contribution",
+}


### PR DESCRIPTION
## Summary
- add a Nodes Contribution utility node that counts workflow nodes by their source suite
- expose the breakdown as a multiline string output, including suites without any workflow nodes

## Testing
- python -m compileall nodes/nodes_contribution.py

------
https://chatgpt.com/codex/tasks/task_e_68d6829697088327a68ff0d4a4347b84